### PR TITLE
editor: remove redundant wrapping func literals

### DIFF
--- a/editor/bitmaps/View.go
+++ b/editor/bitmaps/View.go
@@ -125,9 +125,7 @@ func (view *View) renderContent() {
 
 		render.TextureSelector("###"+"IndexBitmap", -1, view.guiScale, info.MaxCount,
 			view.model.currentKey.Index, view.imageCache,
-			func(index int) resource.Key {
-				return view.indexedResourceKey(index)
-			},
+			view.indexedResourceKey,
 			func(index int) string { return fmt.Sprintf("%d", index) },
 			func(newValue int) {
 				view.model.currentKey.Index = newValue

--- a/editor/levels/ControlView.go
+++ b/editor/levels/ControlView.go
@@ -177,9 +177,8 @@ func (view *ControlView) renderTextureAtlas(lvl *level.Level, readOnly bool) {
 			func(index int) resource.Key {
 				return resource.KeyOf(ids.LargeTextures.Plus(index), resource.LangAny, 0)
 			},
-			func(index int) string {
-				return view.textureName(index)
-			}, func(newIndex int) {
+			view.textureName,
+			func(newIndex int) {
 				view.requestSetLevelTexture(lvl, view.model.selectedAtlasIndex, newIndex)
 			})
 		imgui.SameLine()

--- a/editor/textures/View.go
+++ b/editor/textures/View.go
@@ -91,7 +91,7 @@ func (view *View) renderContent() {
 			func(index int) resource.Key {
 				return view.indexedResourceKey(ids.LargeTextures, index)
 			},
-			func(index int) string { return view.textureTooltip(index) },
+			view.textureTooltip,
 			func(newValue int) {
 				view.model.currentIndex = newValue
 			})


### PR DESCRIPTION
Use function values directly.