### PR TITLE
Some improvements to door, cyberspace terminal,"Set Object Parameter" action and other stuff

### DIFF
--- a/editor/bitmaps/View.go
+++ b/editor/bitmaps/View.go
@@ -29,6 +29,7 @@ var knownBitmapTypes = map[resource.ID]bitmapInfo{
 	ids.ObjectTextureBitmaps:  {title: "Object Textures", languageSpecific: false, bitmapType: bitmap.TypeFlat8Bit, bitmapFlags: 0},
 	ids.IconBitmaps:           {title: "Wall Icons", languageSpecific: false, bitmapType: bitmap.TypeCompressed8Bit, bitmapFlags: bitmap.FlagTransparent},
 	ids.GraffitiBitmaps:       {title: "Graffiti", languageSpecific: false, bitmapType: bitmap.TypeCompressed8Bit, bitmapFlags: bitmap.FlagTransparent},
+	ids.ScreenTextures:        {title: "Screens", languageSpecific: false, bitmapType: bitmap.TypeCompressed8Bit, bitmapFlags: 0},
 }
 
 var knownBitmapTypesOrder = []resource.ID{
@@ -37,6 +38,7 @@ var knownBitmapTypesOrder = []resource.ID{
 	ids.ObjectTextureBitmaps,
 	ids.IconBitmaps,
 	ids.GraffitiBitmaps,
+	ids.ScreenTextures,
 }
 
 // View provides edit controls for bitmaps.

--- a/editor/levels/ObjectsView.go
+++ b/editor/levels/ObjectsView.go
@@ -502,6 +502,23 @@ func (view *ObjectsView) renderPropertyControl(lvl *level.Level, readOnly bool,
 				})
 			})
 	})
+	simplifier.SetSpecialHandler("LockVariable", func() {
+		limit := archive.BooleanVarCount
+		valueLabel := key + "###" + fullKey
+		values.RenderUnifiedSliderInt(readOnly, valueLabel, unifier,
+			func(u values.Unifier) int { return int(u.Unified().(int32)) & 0x1FF },
+			func(value int) string {
+				return fmt.Sprintf("%%d: %s", view.varInfoProvider.BooleanVariable(value).Name)
+			},
+			0, limit-1,
+			func(newValue int) {
+				updater(func(oldValue uint32) uint32 {
+					result := oldValue & ^uint32(0x01FF)
+					result |= uint32(newValue) & uint32(0x01FF)
+					return result
+				})
+			})
+	})
 
 	simplifier.SetSpecialHandler("BinaryCodedDecimal", func() {
 		values.RenderUnifiedSliderInt(readOnly, label, unifier,

--- a/editor/objects/View.go
+++ b/editor/objects/View.go
@@ -132,12 +132,12 @@ func (view *View) renderContent() {
 			}
 			imgui.EndCombo()
 		}
-		view.renderText(readOnly, "Long Name",
+		view.renderText(false, "Long Name",
 			view.objectName(view.model.currentObject, view.model.currentLang, true),
 			func(newValue string) {
 				view.requestSetObjectName(view.model.currentObject, true, newValue)
 			})
-		view.renderText(readOnly, "Short Name",
+		view.renderText(false, "Short Name",
 			view.objectName(view.model.currentObject, view.model.currentLang, false),
 			func(newValue string) {
 				view.requestSetObjectName(view.model.currentObject, false, newValue)

--- a/ss1/content/archive/Variables.go
+++ b/ss1/content/archive/Variables.go
@@ -196,12 +196,18 @@ var engineBooleanVariables = GameVariables{
 	20: GameVariableInfoFor("Reactor on Destruct").At(0).
 		DescribedAs("Note: Rumble will stop if boolean var 152 is 'True'."),
 
+	94: GameVariableInfoFor("Unopenable door").
+		DescribedAs("Doors that are 'broken beyond repair' or such."),
+
 	145: GameVariableInfoFor("On-Line Help"),
 
 	152: GameVariableInfoFor("Self-Destruct Rumble Stop").At(0).
 		DescribedAs("Disables rumble caused by boolean var 20."),
 	153: GameVariableInfoFor("Four or more plastique exploded").At(0).
 		DescribedAs("Set to 'True' if integer variable 2 reached 4 (or higher)."),
+
+	231: GameVariableInfoFor("Unopenable door").
+		DescribedAs("Doors that are 'broken beyond repair' or such."),
 
 	300: GameVariableInfoFor("New Message Flag").At(0),
 }

--- a/ss1/content/archive/level/lvlobj/Doors.go
+++ b/ss1/content/archive/level/lvlobj/Doors.go
@@ -7,7 +7,7 @@ import (
 )
 
 var baseDoor = interpreters.New().
-	With("LockVariableIndex", 0, 2).As(interpreters.RangedValue(0, 0x1FF)).
+	With("LockVariableIndex", 0, 2).As(interpreters.SpecialValue("LockVariable")).
 	With("LockMessageIndex", 2, 1).As(interpreters.FormattedRangedValue(0, 255,
 	func(value int) (result string) {
 		return fmt.Sprintf("%d", value+7)

--- a/ss1/content/archive/level/lvlobj/Fixtures.go
+++ b/ss1/content/archive/level/lvlobj/Fixtures.go
@@ -41,11 +41,7 @@ var retinalIDScanner = recepticlePanel.
 	}))
 
 var cyberspaceTerminal = gameVariablePanel.
-	With("State", 0, 1).As(interpreters.EnumValue(map[uint32]string{0: "Off", 1: "Active", 2: "Locked"})).
-	With("TargetX", 6, 4).As(interpreters.RangedValue(1, 63)).
-	With("TargetY", 10, 4).As(interpreters.RangedValue(1, 63)).
-	With("TargetZ", 14, 4).As(interpreters.RangedValue(0, 255)).
-	With("TargetLevel", 18, 4).As(interpreters.EnumValue(map[uint32]string{10: "10", 14: "14", 15: "15"}))
+	Refining("Action", 0, 22, actions.Unconditional(), interpreters.Always)
 
 var energyChargeStation = gameVariablePanel.
 	With("EnergyDelta", 6, 4).As(interpreters.RangedValue(0, 255)).

--- a/ss1/content/archive/level/lvlobj/actions/Actions.go
+++ b/ss1/content/archive/level/lvlobj/actions/Actions.go
@@ -159,7 +159,8 @@ var exposeDetails = interpreters.New().
 	With("EffectType", 4, 4).As(interpreters.EnumValue(map[uint32]string{4: "Radiation poisoning", 8: "Bio contamination"}))
 
 var setObjectParameterDetails = interpreters.New().
-	With("ObjectID", 0, 4).As(interpreters.ObjectID()).
+	With("ObjectID1", 0, 2).As(interpreters.ObjectID()).
+	With("ObjectID2", 2, 2).As(interpreters.ObjectID()).
 	With("Value1", 4, 4).
 	With("Value2", 8, 4).
 	With("Value3", 12, 4)

--- a/ss1/world/ids/Identifier.go
+++ b/ss1/world/ids/Identifier.go
@@ -14,6 +14,8 @@ const (
 	MediumTextures resource.ID = 0x02C3
 	LargeTextures  resource.ID = 0x03E8
 
+	ScreenTextures resource.ID = 0x0141
+
 	TextureNames  resource.ID = 0x086A
 	TextureUsages resource.ID = 0x086B
 )

--- a/ss1/world/ids/Info.go
+++ b/ss1/world/ids/Info.go
@@ -152,6 +152,7 @@ var infoList = []ResourceInfo{
 	{LogsAudioStart, LogsAudioStart.Plus(224), resource.Movie, false, false, false, 224, CitALog},
 
 	{ObjectLongNames, ObjectLongNames.Plus(1), resource.Text, true, false, true, 0, CybStrng},
+	{ObjectShortNames, ObjectShortNames.Plus(1), resource.Text, true, false, true, 0, CybStrng},
 
 	{ArchiveName, ArchiveName.Plus(1), resource.Archive, false, false, false, 1, Archive},
 	{GameState, GameState.Plus(1), resource.Archive, false, true, false, 1, Archive},

--- a/ss1/world/ids/Info.go
+++ b/ss1/world/ids/Info.go
@@ -117,6 +117,8 @@ var infoList = []ResourceInfo{
 	{ObjectTextureBitmaps, ObjectTextureBitmaps.Plus(64), resource.Bitmap, true, false, false, 64, CitMat},
 	{ObjectMaterialBitmaps, ObjectMaterialBitmaps.Plus(32), resource.Bitmap, true, false, false, 32, CitMat},
 
+	{ScreenTextures, ScreenTextures.Plus(102), resource.Bitmap, true, false, false, 102, Texture},
+
 	{IconBitmaps, IconBitmaps.Plus(1), resource.Bitmap, true, false, true, 64, ObjArt3},
 	{GraffitiBitmaps, GraffitiBitmaps.Plus(1), resource.Bitmap, true, false, true, 64, ObjArt3},
 


### PR DESCRIPTION
Some improvements.

Shows name of lock variable. This is incomplete solution because when access level is 255 it should be object id.

Added hardcoded door lock variable bits 94 and 231. They force door to be locked even in lower difficulties. [really_really_locked](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/objuse.c#L178)

Cyberspace terminals are just regular fixtures with action. [obj_fixture_zoom](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/objuse.c#L933)

Set object parameters reference have two targets. [trap_instance_func](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/trigger.c#L1317)

Fixed saving of object short name.

Allow editing object names.

Added screens to Bitmap window.
