### PR TITLE
More features

### DIFF
--- a/editor/levels/TilesView.go
+++ b/editor/levels/TilesView.go
@@ -124,6 +124,7 @@ func (view *TilesView) renderContent(lvl *level.Level, tiles []*level.TileMapEnt
 		slopeHeightUnifier.Add(tile.SlopeHeight)
 		slopeControlUnifier.Add(tile.Flags.SlopeControl())
 		musicZoneUnifier.Add(tile.Flags.MusicZone())
+		perildUnifier.Add(tile.Flags.Peril())
 		if isCyberspace {
 			floorPaletteIndexUnifier.Add(tile.TextureInfo.FloorPaletteIndex())
 			ceilingPaletteIndexUnifier.Add(tile.TextureInfo.CeilingPaletteIndex())
@@ -144,7 +145,6 @@ func (view *TilesView) renderContent(lvl *level.Level, tiles []*level.TileMapEnt
 			ceilingLightUnifier.Add(level.GradesOfShadow - 1 - flags.CeilingShadow())
 			ceilingLightDeltaUnifier.Add(tile.LightDelta.OfCeiling())
 			deconstructedUnifier.Add(flags.Deconstructed())
-			perildUnifier.Add(flags.Peril())
 			floorHazardUnifier.Add(tile.Floor.HasHazard())
 			ceilingHazardUnifier.Add(tile.Ceiling.HasHazard())
 		}
@@ -188,6 +188,8 @@ func (view *TilesView) renderContent(lvl *level.Level, tiles []*level.TileMapEnt
 		func(value int) string { return musicZones[value].String() },
 		len(musicZones),
 		func(newValue int) { view.changeTiles(setMusicZoneTo(musicZones[newValue])) })
+	values.RenderUnifiedCheckboxCombo(readOnly, "Music Peril", perildUnifier,
+		func(newValue bool) { view.changeTiles(setPerilTo(newValue)) })
 
 	imgui.Separator()
 
@@ -330,8 +332,6 @@ func (view *TilesView) renderContent(lvl *level.Level, tiles []*level.TileMapEnt
 
 		values.RenderUnifiedCheckboxCombo(readOnly, "Deconstructed", deconstructedUnifier,
 			func(newValue bool) { view.changeTiles(setDeconstructedTo(newValue)) })
-		values.RenderUnifiedCheckboxCombo(readOnly, "Peril", perildUnifier,
-			func(newValue bool) { view.changeTiles(setPerilTo(newValue)) })
 		values.RenderUnifiedCheckboxCombo(readOnly, "Floor Hazard", floorHazardUnifier,
 			func(newValue bool) { view.changeTiles(setFloorHazardTo(newValue)) })
 		values.RenderUnifiedCheckboxCombo(readOnly, "Ceiling Hazard", ceilingHazardUnifier,
@@ -402,6 +402,12 @@ func setSlopeHeightTo(height level.TileHeightUnit) tileMapEntryModifier {
 func setSlopeControlTo(value level.TileSlopeControl) tileMapEntryModifier {
 	return func(tile *level.TileMapEntry) {
 		tile.Flags = tile.Flags.WithSlopeControl(value)
+	}
+}
+
+func setPerilTo(value bool) tileMapEntryModifier {
+	return func(tile *level.TileMapEntry) {
+		tile.Flags = tile.Flags.WithPeril(value)
 	}
 }
 
@@ -486,12 +492,6 @@ func setCeilingLightDeltaTo(value int) tileMapEntryModifier {
 func setDeconstructedTo(value bool) tileMapEntryModifier {
 	return func(tile *level.TileMapEntry) {
 		tile.Flags = tile.Flags.ForRealWorld().WithDeconstructed(value).AsTileFlag()
-	}
-}
-
-func setPerilTo(value bool) tileMapEntryModifier {
-	return func(tile *level.TileMapEntry) {
-		tile.Flags = tile.Flags.ForRealWorld().WithPeril(value).AsTileFlag()
 	}
 }
 

--- a/ss1/content/archive/level/TileFlag.go
+++ b/ss1/content/archive/level/TileFlag.go
@@ -31,6 +31,20 @@ func (flag TileFlag) WithMusicZone(value TileMusicZone) TileFlag {
 	return TileFlag(uint32(flag&^0x0000E000) | (uint32(value) << 13))
 }
 
+// Peril returns whether the tile is marked as peril (may play peril music).
+func (flag TileFlag) Peril() bool {
+	return (flag & 0x00001000) != 0
+}
+
+// WithPeril returns a flag with the given peril set.
+func (flag TileFlag) WithPeril(value bool) TileFlag {
+	var valueFlag uint32
+	if value {
+		valueFlag = 0x00001000
+	}
+	return TileFlag(uint32(flag&^0x00001000) | valueFlag)
+}
+
 // SlopeControl returns the slope control as per flags.
 func (flag TileFlag) SlopeControl() TileSlopeControl {
 	return TileSlopeControl((flag & 0x00000C00) >> 10)
@@ -92,20 +106,6 @@ func (flag RealWorldFlag) WithDeconstructed(value bool) RealWorldFlag {
 		valueFlag = 0x00000200
 	}
 	return RealWorldFlag(uint32(flag&^0x00000200) | valueFlag)
-}
-
-// Peril returns whether the tile is marked as peril (may play peril music).
-func (flag RealWorldFlag) Peril() bool {
-	return (flag & 0x00001000) != 0
-}
-
-// WithPeril returns a flag with the given peril set.
-func (flag RealWorldFlag) WithPeril(value bool) RealWorldFlag {
-	var valueFlag uint32
-	if value {
-		valueFlag = 0x00001000
-	}
-	return RealWorldFlag(uint32(flag&^0x00001000) | valueFlag)
 }
 
 // FloorShadow returns the floor shadow value. Range: [0..GradesOfShadow].

--- a/ss1/content/archive/level/TileFlag.go
+++ b/ss1/content/archive/level/TileFlag.go
@@ -1,5 +1,7 @@
 package level
 
+import "fmt"
+
 // TileFlag describes simple properties of a map tile.
 type TileFlag uint32
 
@@ -19,17 +21,14 @@ func (flag TileFlag) ForCyberspace() CyberspaceFlag {
 	return CyberspaceFlag(flag)
 }
 
-// MusicIndex returns the music identifier. Range: [0..15].
-func (flag TileFlag) MusicIndex() int {
-	return int((flag & 0x0000F000) >> 12)
+// MusicZone returns the music zone.
+func (flag TileFlag) MusicZone() TileMusicZone {
+	return TileMusicZone((flag & 0x0000E000) >> 13)
 }
 
-// WithMusicIndex returns a new flag value with the given music index set. Values beyond allowed range are ignored.
-func (flag TileFlag) WithMusicIndex(value int) TileFlag {
-	if (value < 0) || (value > 15) {
-		return flag
-	}
-	return TileFlag(uint32(flag&^0x0000F000) | (uint32(value) << 12))
+// WithMusicZone returns a new flag value with the given music index set.
+func (flag TileFlag) WithMusicZone(value TileMusicZone) TileFlag {
+	return TileFlag(uint32(flag&^0x0000E000) | (uint32(value) << 13))
 }
 
 // SlopeControl returns the slope control as per flags.
@@ -95,6 +94,20 @@ func (flag RealWorldFlag) WithDeconstructed(value bool) RealWorldFlag {
 	return RealWorldFlag(uint32(flag&^0x00000200) | valueFlag)
 }
 
+// Peril returns whether the tile is marked as peril (may play peril music).
+func (flag RealWorldFlag) Peril() bool {
+	return (flag & 0x00001000) != 0
+}
+
+// WithPeril returns a flag with the given peril set.
+func (flag RealWorldFlag) WithPeril(value bool) RealWorldFlag {
+	var valueFlag uint32
+	if value {
+		valueFlag = 0x00001000
+	}
+	return RealWorldFlag(uint32(flag&^0x00001000) | valueFlag)
+}
+
 // FloorShadow returns the floor shadow value. Range: [0..GradesOfShadow].
 func (flag RealWorldFlag) FloorShadow() int {
 	return int((flag & 0x000F0000) >> 16)
@@ -126,7 +139,7 @@ func (flag RealWorldFlag) TileVisited() bool {
 	return (flag & 0x80000000) != 0
 }
 
-// WithTileVisited returns a flag with the given deconstruction set.
+// WithTileVisited returns a flag with the given visited set.
 func (flag RealWorldFlag) WithTileVisited(value bool) RealWorldFlag {
 	var valueFlag uint32
 	if value {
@@ -161,4 +174,54 @@ func (flag CyberspaceFlag) WithFlightPull(value CyberspaceFlightPull) Cyberspace
 	newFlag |= uint32(value&0x0F) << 16
 	newFlag |= uint32(value&0x10) << 20
 	return CyberspaceFlag(newFlag)
+}
+
+type TileMusicZone byte
+
+const (
+	TileMusicZoneNoMusic    TileMusicZone = 0
+	TileMusicZoneHospital   TileMusicZone = 1
+	TileMusicZoneExecutive  TileMusicZone = 2
+	TileMusicZoneIndustrial TileMusicZone = 3
+	TileMusicZoneMetal      TileMusicZone = 4
+	TileMusicZonePark       TileMusicZone = 5
+	TileMusicZoneBridge     TileMusicZone = 6
+	TileMusicZoneElevator   TileMusicZone = 7
+)
+
+// TileSlopeControls returns all control values.
+func TileMusicZones() []TileMusicZone {
+	return []TileMusicZone{
+		TileMusicZoneNoMusic,
+		TileMusicZoneHospital,
+		TileMusicZoneExecutive,
+		TileMusicZoneIndustrial,
+		TileMusicZoneMetal,
+		TileMusicZonePark,
+		TileMusicZoneBridge,
+		TileMusicZoneElevator,
+	}
+}
+
+func (ctrl TileMusicZone) String() string {
+	switch ctrl {
+	case TileMusicZoneNoMusic:
+		return "No Music"
+	case TileMusicZoneHospital:
+		return "Hospital"
+	case TileMusicZoneExecutive:
+		return "Executive"
+	case TileMusicZoneIndustrial:
+		return "Industrial"
+	case TileMusicZoneMetal:
+		return "Metal"
+	case TileMusicZonePark:
+		return "Park"
+	case TileMusicZoneBridge:
+		return "Bridge"
+	case TileMusicZoneElevator:
+		return "Elevator"
+	default:
+		return fmt.Sprintf("Unknown%02X", int(ctrl))
+	}
 }

--- a/ss1/content/archive/level/lvlobj/BigStuff.go
+++ b/ss1/content/archive/level/lvlobj/BigStuff.go
@@ -6,19 +6,21 @@ import (
 
 var baseBigStuff = interpreters.New()
 
+var multiAnimation = interpreters.New().
+	With("LoopType", 0, 2).As(interpreters.Bitfield(map[uint32]string{0x01: "Forward/Backward", 0x02: "Backward"})).
+	With("Alternation", 2, 2).As(interpreters.SpecialValue("MultiAnimation")).
+	With("Picture", 4, 2).As(interpreters.SpecialValue("PictureSource")).
+	With("Alternate", 6, 2).As(interpreters.SpecialValue("PictureSource"))
+
 var displayScenery = baseBigStuff.
-	With("FrameCount", 0, 2).As(interpreters.RangedValue(0, 4)).
-	With("LoopType", 2, 2).As(interpreters.EnumValue(map[uint32]string{0: "Forward", 1: "Forward/Backward", 2: "Backward", 3: "Forward/Backward"})).
-	With("AlternationType", 4, 2).As(interpreters.EnumValue(map[uint32]string{0: "Don't Alternate", 3: "Alternate Randomly"})).
-	With("PictureSource", 6, 2).As(interpreters.RangedValue(0, 0x01FF)).
-	With("AlternateSource", 8, 2).As(interpreters.RangedValue(0, 0x01FF))
+	With("FrameCount", 0, 2).As(interpreters.RangedValue(0, 8)).
+	Refining("", 2, 8, multiAnimation, interpreters.Always)
 
 var displayControlPedestal = baseBigStuff.
-	With("FrameCount", 0, 2).As(interpreters.RangedValue(0, 4)).
-	With("TriggerObjectID", 2, 2).As(interpreters.ObjectID()).
-	With("AlternationType", 4, 2).As(interpreters.EnumValue(map[uint32]string{0: "Don't Alternate", 3: "Alternate Randomly"})).
-	With("PictureSource", 6, 2).As(interpreters.RangedValue(0, 0x01FF)).
-	With("AlternateSource", 8, 2).As(interpreters.RangedValue(0, 0x01FF))
+	With("FrameCount", 0, 2).As(interpreters.RangedValue(0, 8)).
+	With("TriggerObjectID1", 2, 2).As(interpreters.ObjectID()).
+	With("TriggerObjectID2", 4, 2).As(interpreters.ObjectID()).
+	Refining("", 2, 8, multiAnimation, interpreters.Always)
 
 var cabinetFurniture = baseBigStuff.
 	With("Object1ID", 2, 2).As(interpreters.ObjectID()).
@@ -38,7 +40,8 @@ var textureMapScenery = baseBigStuff.
 	With("TextureIndex", 6, 2).As(interpreters.SpecialValue("LevelTexture"))
 
 var buttonControlPedestal = baseBigStuff.
-	With("TriggerObjectID", 2, 2).As(interpreters.ObjectID())
+	With("TriggerObjectID1", 2, 2).As(interpreters.ObjectID()).
+	With("TriggerObjectID2", 4, 2).As(interpreters.ObjectID())
 
 var surgicalMachine = baseBigStuff.
 	With("BrokenState", 2, 1).As(interpreters.EnumValue(map[uint32]string{0x00: "OK", 0xE7: "Broken"})).
@@ -91,6 +94,7 @@ func initBigStuff() interpreterRetriever {
 
 	scienceSecurityEquipment := newInterpreterEntry(baseBigStuff)
 	scienceSecurityEquipment.set(4, newInterpreterLeaf(securityCamera))
+	scienceSecurityEquipment.set(5, newInterpreterLeaf(buttonControlPedestal))
 	scienceSecurityEquipment.set(6, newInterpreterLeaf(displayControlPedestal))
 
 	gardenScenery := newInterpreterEntry(baseBigStuff)

--- a/ss1/content/archive/level/lvlobj/BigStuff.go
+++ b/ss1/content/archive/level/lvlobj/BigStuff.go
@@ -27,7 +27,7 @@ var cabinetFurniture = baseBigStuff.
 	With("Object2ID", 4, 2).As(interpreters.ObjectID())
 
 var texturableFurniture = baseBigStuff.
-	With("TextureIndex", 6, 2).As(interpreters.RangedValue(0, 500))
+	With("Texture", 6, 2).As(interpreters.SpecialValue("PictureSource"))
 
 var wordScenery = baseBigStuff.
 	With("TextIndex", 0, 2).As(interpreters.RangedValue(0, 511)).


### PR DESCRIPTION
Added special handler for screens and objects with picture source. [bitmap_from_tpoly_data](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/objsim.c#L321)
In [multi_anim_callback](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/objuse.c#L1495) it was planned to have other switching types than "random". I added selection code for it, but commented it out. I named the value "infrequency" since larger values means it switches less frequent. 2 or 3 are good values. 4 takes quite a long time to switch. If I remember correctly.
Texture preview is not perfect, but couldn't figure out a better way to show it.

Changed music index to following:
Added [Music zones](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/Headers/musicai.h#L52-L59). Map data it is [only 3 bits](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/Headers/mapflags.h#L116C30-L116C32)
Added [Peril flag](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/Headers/mapflags.h#L235). It is music modifier similar to deconstructed, but is more dynamic. I think nearby enemies have something to do with it. In cyberspace it adds [NUM_NODE_THEMES (2)](https://github.com/Interrupt/systemshock/blob/ae36cec2c301a0b28221eb499cf23208be65f316/src/GameSrc/musicai.c#L215) to music zone.

ButtonControlPedestal has two targets
Added missing "scienceSecurityEquipment"
