### PR TITLE
Hacked2/add unit test framework

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,5 @@
 ---
-Language: C
+Language: Cpp
 AccessModifierOffset: -3
 AlignAfterOpenBracket: false
 AlignConsecutiveAssignments: None

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -91,8 +91,8 @@ jobs:
         run: cmake --build build -j $(sysctl -n hw.logicalcpu || nproc)
 
       - name: Run tests
-        if: matrix.os != 'msdos'
-        run: ctest --test-dir build
+        if: matrix.os == 'linux' || matrix.os == 'macos'
+        run: ctest --test-dir build --output-on-failure
 
       - name: Prepare distribution package
         run: cmake --install build --prefix dist

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -47,6 +47,7 @@ jobs:
             arch: i586
             runner: ubuntu-24.04
             toolchain_file: 'i586-msdosdjgpp.cmake'
+            extra_packages: 'libefl-all-dev'
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Install build dependencies (MS DOS)
         if: matrix.os == 'msdos'
         run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ${{ matrix.extra_packages }}
           wget -q https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
           tar -xjf djgpp-linux64-gcc1220.tar.bz2 -C "${{ runner.temp }}"
           echo "${{ runner.temp }}/djgpp/bin" >> $GITHUB_PATH

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -90,6 +90,10 @@ jobs:
       - name: Build
         run: cmake --build build -j $(sysctl -n hw.logicalcpu || nproc)
 
+      - name: Run tests
+        if: matrix.os != 'msdos'
+        run: ctest --test-dir build
+
       - name: Prepare distribution package
         run: cmake --install build --prefix dist
 

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -47,7 +47,7 @@ jobs:
             arch: i586
             runner: ubuntu-24.04
             toolchain_file: 'i586-msdosdjgpp.cmake'
-            extra_packages: 'libefl-all-dev'
+            extra_packages: 'libfl-dev'
 
     steps:
       - uses: actions/checkout@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if (NOT DOS)
             hacked-core
             GTest::gmock_main
     )
-    gtest_add_tests(TARGET hacked-core-test)
+    gtest_add_tests(TARGET hacked-core-test EXTRA_ARGS --gtest_shuffle)
 endif ()
 
 add_executable(hacked main.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,13 +12,16 @@ include(FetchContent)
 
 FetchContent_Declare(
         googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # release-1.12.1
+        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
         OVERRIDE_FIND_PACKAGE
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
+
+# Disable POSIX regular expressions for GoogleTest targets
+target_compile_definitions(gtest PUBLIC GTEST_USES_POSIX_RE=0)
+target_compile_definitions(gmock PUBLIC GTEST_USES_POSIX_RE=0)
 
 file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
 add_library(hacked-core STATIC ${LIB_CORE_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0077 NEW) # Abort if variables are not clearly set
 
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-#set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
+set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
 #set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
@@ -30,8 +30,8 @@ if (DOS)
     )
 endif ()
 # Disable POSIX regular expressions for GoogleTest targets
-target_compile_definitions(gtest PUBLIC GTEST_HAS_POSIX_RE=0)
-target_compile_definitions(gmock PUBLIC GTEST_HAS_POSIX_RE=0)
+target_compile_definitions(gtest PUBLIC GTEST_HAS_POSIX_RE=0 GTEST_HAS_STD_WSTRING=0)
+target_compile_definitions(gmock PUBLIC GTEST_HAS_POSIX_RE=0 GTEST_HAS_STD_WSTRING=0)
 
 file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
 add_library(hacked-core STATIC ${LIB_CORE_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,14 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 if (DOS)
-    target_compile_features(gtest PRIVATE -std=gnu++17)
-    target_compile_features(gmock PRIVATE -std=gnu++17)
+    set_target_properties(gtest PROPERTIES
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS ON
+    )
+    set_target_properties(gmock PROPERTIES
+            CXX_STANDARD_REQUIRED ON
+            CXX_EXTENSIONS ON
+    )
 endif ()
 # Disable POSIX regular expressions for GoogleTest targets
 target_compile_definitions(gtest PUBLIC GTEST_HAS_POSIX_RE=0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ cmake_policy(SET CMP0077 NEW) # Abort if variables are not clearly set
 
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-#set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
-#set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 
@@ -19,30 +19,18 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-if (DOS)
-    set_target_properties(gtest PROPERTIES
-            CXX_STANDARD_REQUIRED OFF
-            CXX_EXTENSIONS ON
-    )
-    set_target_properties(gmock PROPERTIES
-            CXX_STANDARD_REQUIRED OFF
-            CXX_EXTENSIONS ON
-    )
-endif ()
-# Disable POSIX regular expressions for GoogleTest targets
-target_compile_definitions(gtest PUBLIC GTEST_HAS_POSIX_RE=0 GTEST_HAS_STD_WSTRING=0)
-target_compile_definitions(gmock PUBLIC GTEST_HAS_POSIX_RE=0 GTEST_HAS_STD_WSTRING=0)
-
 file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
 add_library(hacked-core STATIC ${LIB_CORE_SOURCES})
 target_include_directories(hacked-core PUBLIC "${PROJECT_SOURCE_DIR}/core/main/include")
 
-file(GLOB_RECURSE TEST_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/test/source/*.cpp")
-add_executable(hacked-core-test ${TEST_CORE_SOURCES})
-target_link_libraries(hacked-core-test
-        hacked-core
-        GTest::gmock_main
-)
+if (!DOS)
+    file(GLOB_RECURSE TEST_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/test/source/*.cpp")
+    add_executable(hacked-core-test ${TEST_CORE_SOURCES})
+    target_link_libraries(hacked-core-test
+            hacked-core
+            GTest::gmock_main
+    )
+endif ()
 
 add_executable(hacked main.c)
 target_link_libraries(hacked

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,37 @@
 cmake_minimum_required(VERSION 3.28)
-project(Hacked LANGUAGES C)
+project(Hacked)
 
-add_executable(hacked
-        main.c
+cmake_policy(SET CMP0077 NEW) # Abort if variables are not clearly set
+
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+
+FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
+add_library(hacked-core STATIC ${LIB_CORE_SOURCES})
+target_include_directories(hacked-core PUBLIC "${PROJECT_SOURCE_DIR}/core/main/include")
+
+file(GLOB_RECURSE TEST_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/test/source/*.cpp")
+add_executable(hacked-core-test ${TEST_CORE_SOURCES})
+target_link_libraries(hacked-core-test
+        hacked-core
+        GTest::gmock_main
+)
+
+add_executable(hacked main.c)
+target_link_libraries(hacked
+        hacked-core
 )
 
 install(TARGETS hacked

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
+if (DOS)
+    target_compile_features(gtest PRIVATE -std=gnu++17)
+    target_compile_features(gmock PRIVATE -std=gnu++17)
+endif ()
 # Disable POSIX regular expressions for GoogleTest targets
 target_compile_definitions(gtest PUBLIC GTEST_HAS_POSIX_RE=0)
 target_compile_definitions(gmock PUBLIC GTEST_HAS_POSIX_RE=0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0077 NEW) # Abort if variables are not clearly set
 
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
+#set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
 #set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
 # Disable POSIX regular expressions for GoogleTest targets
-target_compile_definitions(gtest PUBLIC GTEST_USES_POSIX_RE=0)
-target_compile_definitions(gmock PUBLIC GTEST_USES_POSIX_RE=0)
+target_compile_definitions(gtest PUBLIC GTEST_HAS_POSIX_RE=0)
+target_compile_definitions(gmock PUBLIC GTEST_HAS_POSIX_RE=0)
 
 file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
 add_library(hacked-core STATIC ${LIB_CORE_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,16 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 
-FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
-        OVERRIDE_FIND_PACKAGE
-)
-# For Windows: Prevent overriding the parent project's compiler/linker settings
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+if (!DOS)
+    FetchContent_Declare(
+            googletest
+            URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+            OVERRIDE_FIND_PACKAGE
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+endif ()
 
 file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
 add_library(hacked-core STATIC ${LIB_CORE_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,9 @@ set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
+include(CTest)
 
-if (!DOS)
+if (NOT DOS)
     FetchContent_Declare(
             googletest
             URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
@@ -19,19 +20,21 @@ if (!DOS)
     # For Windows: Prevent overriding the parent project's compiler/linker settings
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
+    include(GoogleTest)
 endif ()
 
 file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
 add_library(hacked-core STATIC ${LIB_CORE_SOURCES})
 target_include_directories(hacked-core PUBLIC "${PROJECT_SOURCE_DIR}/core/main/include")
 
-if (!DOS)
+if (NOT DOS)
     file(GLOB_RECURSE TEST_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/test/source/*.cpp")
     add_executable(hacked-core-test ${TEST_CORE_SOURCES})
     target_link_libraries(hacked-core-test
             hacked-core
             GTest::gmock_main
     )
+    gtest_add_tests(TARGET hacked-core-test)
 endif ()
 
 add_executable(hacked main.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,9 @@ include(FetchContent)
 
 FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG 58d77fa8070e8cec2dc1ed015d66b454c8d78850 # release-1.12.1
+        OVERRIDE_FIND_PACKAGE
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ cmake_policy(SET CMP0077 NEW) # Abort if variables are not clearly set
 
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+#set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
+#set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 
@@ -21,11 +21,11 @@ FetchContent_MakeAvailable(googletest)
 
 if (DOS)
     set_target_properties(gtest PROPERTIES
-            CXX_STANDARD_REQUIRED ON
+            CXX_STANDARD_REQUIRED OFF
             CXX_EXTENSIONS ON
     )
     set_target_properties(gmock PROPERTIES
-            CXX_STANDARD_REQUIRED ON
+            CXX_STANDARD_REQUIRED OFF
             CXX_EXTENSIONS ON
     )
 endif ()

--- a/core/main/include/hacked/core/Core.h
+++ b/core/main/include/hacked/core/Core.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int32_t sampleReturn(int32_t input);
+
+#ifdef __cplusplus
+}
+#endif

--- a/core/main/source/Core.c
+++ b/core/main/source/Core.c
@@ -1,0 +1,6 @@
+#include "hacked/core/Core.h"
+
+int32_t sampleReturn(int32_t input)
+{
+   return input + 10;
+}

--- a/core/test/source/CoreTest.cpp
+++ b/core/test/source/CoreTest.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+#include "hacked/core/Core.h"
+
+TEST(CoreTest, sample)
+{
+   EXPECT_EQ(12, sampleReturn(2)) << "failure";
+}

--- a/main.c
+++ b/main.c
@@ -1,8 +1,10 @@
 #include <stdio.h>
 
-int main(int const argc, char const *const *argv)
+#include "hacked/core/Core.h"
+
+int main(int const argc, char const *argv[])
 {
-   printf("hacked with %d arguments\n", argc);
+   printf("hacked with %d arguments; sampleReturn: %d\n", argc, sampleReturn(2));
    for (int i = 0; i < argc; i++)
    {
       printf("%02d: '%s'\n", i, argv[i]);


### PR DESCRIPTION
This pull request adds the unit testing framework `GooleTest`. Sadly I could not find/use a C-only unit testing framework. There's no support for CMocka in CLion for example. As a result, it will sneak in come C++ code for the testing code.

Furthermore, due to the high compiler demands of GoogleTest, they can not be satisfied with the MS DOS build currently. I hope that GCC 15 will be integrated into djgpp eventually. This would improve language support greatly, also for C23.
