### PR TITLE
Hacked2/add wasm build

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -87,7 +87,7 @@ jobs:
         if: matrix.os == 'wasm'
         run: |
           pushd "${HOME}" > /dev/null || exit 1
-          wget -q https://github.com/emscripten-core/emsdk.git
+          git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
           ./emsdk install 6.0.4
           ./emsdk activate 6.0.4

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -105,6 +105,9 @@ jobs:
       - name: Build
         run: cmake --build build -j $(sysctl -n hw.logicalcpu || nproc)
 
+      - name: List build output
+        run: ls -la build/
+
       - name: Run tests
         if: matrix.os == 'linux' || matrix.os == 'macos'
         run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -15,26 +15,26 @@ jobs:
           - os: linux
             arch: x86-64
             runner: ubuntu-24.04
-            toolchain_file: 'x86-64-gcc.cmake'
+            toolchain_file: 'cmake/toolchains/x86-64-gcc.cmake'
             extra_packages: 'gcc g++ mesa-utils mesa-common-dev xorg-dev libxrandr-dev'
 
           - os: linux
             arch: i686
             runner: ubuntu-24.04
-            toolchain_file: 'i686-gcc.cmake'
+            toolchain_file: 'cmake/toolchains/i686-gcc.cmake'
             extra_packages: 'gcc-multilib g++-multilib mesa-utils mesa-common-dev:i386 xorg-dev libxrandr-dev:i386 libxcursor-dev:i386 libxi-dev:i386'
 
           # MS Windows builds
           - os: mswin
             arch: x86-64
             runner: ubuntu-24.04
-            toolchain_file: 'x86-64-w64-mingw32.cmake'
+            toolchain_file: 'cmake/toolchains/x86-64-w64-mingw32.cmake'
             extra_packages: 'gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64'
 
           - os: mswin
             arch: i686
             runner: ubuntu-24.04
-            toolchain_file: 'i686-w64-mingw32.cmake'
+            toolchain_file: 'cmake/toolchains/i686-w64-mingw32.cmake'
             extra_packages: 'gcc-mingw-w64-i686 g++-mingw-w64-i686'
 
           # macOS builds (native compilation)
@@ -46,8 +46,13 @@ jobs:
           - os: msdos
             arch: i586
             runner: ubuntu-24.04
-            toolchain_file: 'i586-msdosdjgpp.cmake'
+            toolchain_file: 'cmake/toolchains/i586-msdosdjgpp.cmake'
             extra_packages: 'libfl-dev'
+
+          - os: wasm
+            arch: x86
+            runner: ubuntu-24.04
+            toolchain_file: '${HOME}/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake'
 
     steps:
       - uses: actions/checkout@v7
@@ -77,6 +82,16 @@ jobs:
           wget -q https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
           tar -xjf djgpp-linux64-gcc1220.tar.bz2 -C "${{ runner.temp }}"
           echo "${{ runner.temp }}/djgpp/bin" >> $GITHUB_PATH
+
+      - name: Install build dependencies (WASM)
+        if: matrix.os == 'wasm'
+        run: |
+          pushd "${HOME}" > /dev/null || exit 1
+          wget -q https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          ./emsdk install 6.0.4
+          ./emsdk activate 6.0.4
+          popd > /dev/null || exit 1
 
       - name: Generate build files
         run: >

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -100,7 +100,7 @@ jobs:
           -S . 
           -G Ninja
           -DCMAKE_BUILD_TYPE=RelWithDebInfo 
-          ${{ matrix.toolchain_file && format('-DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/{0}', matrix.toolchain_file) || '' }}
+          ${{ matrix.toolchain_file && format('-DCMAKE_TOOLCHAIN_FILE={0}', matrix.toolchain_file) || '' }}
 
       - name: Build
         run: cmake --build build -j $(sysctl -n hw.logicalcpu || nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,9 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 else ()
     add_executable(hacked WIN32 ${APP_GUI_SOURCES})
 endif ()
-if (CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+if (EMSCRIPTEN)
     set_target_properties(hacked PROPERTIES SUFFIX ".html")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s ASSERTIONS=1 -s WASM=1 -s ASYNCIFY -s GL_ENABLE_GET_PROC_ADDRESS=1")
+    #set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s ASSERTIONS=1 -s WASM=1 -s ASYNCIFY -s GL_ENABLE_GET_PROC_ADDRESS=1")
 endif ()
 target_link_libraries(hacked
         hacked-core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,10 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 else ()
     add_executable(hacked WIN32 ${APP_GUI_SOURCES})
 endif ()
+if (CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+    set_target_properties(hacked PROPERTIES SUFFIX ".html")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s ASSERTIONS=1 -s WASM=1 -s ASYNCIFY -s GL_ENABLE_GET_PROC_ADDRESS=1")
+endif ()
 target_link_libraries(hacked
         hacked-core
         SDL3::SDL3-static

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,6 @@ if (EMSCRIPTEN)
     install(FILES
             "$<TARGET_FILE_DIR:hacked>/hacked.js"
             "$<TARGET_FILE_DIR:hacked>/hacked.wasm"
-            RUNTIME DESTINATION .
+            DESTINATION .
     )
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,3 +96,11 @@ endif ()
 install(TARGETS hacked
         RUNTIME DESTINATION .
 )
+
+if (EMSCRIPTEN)
+    install(FILES
+            "$<CMAKE_BINARY_DIR:hacked>/hacked.js"
+            "$<CMAKE_BINARY_DIR:hacked>/hacked.wasm"
+            RUNTIME DESTINATION .
+    )
+endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,8 +68,7 @@ else ()
     add_executable(hacked WIN32 ${APP_GUI_SOURCES})
 endif ()
 if (EMSCRIPTEN)
-    set_target_properties(hacked PROPERTIES SUFFIX ".html")
-    #set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s ASSERTIONS=1 -s WASM=1 -s ASYNCIFY -s GL_ENABLE_GET_PROC_ADDRESS=1")
+    set_target_properties(hacked PROPERTIES SUFFIX ".html") # Tell Emscripten to also create .html for this (needed?)
 endif ()
 target_link_libraries(hacked
         hacked-core
@@ -98,6 +97,9 @@ install(TARGETS hacked
 )
 
 if (EMSCRIPTEN)
+    # As per CMake "bug", the additional files have to be manually taken into the installation directory as well.
+    # Reference:
+    # https://stackoverflow.com/questions/61865545/how-to-install-both-js-and-wasm-files-with-the-cmake-target-for-emscripten#comment140265783_70702138
     install(FILES
             "$<TARGET_FILE_DIR:hacked>/hacked.js"
             "$<TARGET_FILE_DIR:hacked>/hacked.wasm"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,8 @@ install(TARGETS hacked
 
 if (EMSCRIPTEN)
     install(FILES
-            "$<CMAKE_BINARY_DIR:hacked>/hacked.js"
-            "$<CMAKE_BINARY_DIR:hacked>/hacked.wasm"
+            "$<TARGET_FILE_DIR:hacked>/hacked.js"
+            "$<TARGET_FILE_DIR:hacked>/hacked.wasm"
             RUNTIME DESTINATION .
     )
 endif ()


### PR DESCRIPTION
This pull request adds WebAssembly creation to the targets, yay!
The artifact also includes a sample HTML page to showcase the result.

Tests are not yet executed, yet could be with runtimes like wasmtime.