### PR TITLE
Hacked2/refine build procedure

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -74,7 +74,8 @@ jobs:
           set -e
           brew uninstall cmake || true
           wget -q https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-macos-universal.tar.gz
-          echo "799af7fd545db9bf1b9cfe72f8095880e727a2d4e0df0e3dffc3bc7b95c2d3b0 *cmake-3.31.12-macos-universal.tar.gz" | sha256sum --check --status -
+          echo "799af7fd545db9bf1b9cfe72f8095880e727a2d4e0df0e3dffc3bc7b95c2d3b0 *cmake-3.31.12-macos-universal.tar.gz" > sha256sums.txt
+          shasum --algorithm 256 --check sha256sums.txt
           tar -xzf cmake-3.31.12-macos-universal.tar.gz
           sudo cp -r cmake-3.31.12-macos-universal/CMake.app /Applications/
           echo "/Applications/CMake.app/Contents/bin" >> $GITHUB_PATH

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -72,7 +72,7 @@ jobs:
         if: matrix.os == 'macos'
         run: |
           set -e
-          brew uninstall -y cmake || true
+          brew uninstall cmake || true
           wget -q https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-macos-universal.tar.gz
           echo "799af7fd545db9bf1b9cfe72f8095880e727a2d4e0df0e3dffc3bc7b95c2d3b0 *cmake-3.31.12-macos-universal.tar.gz" | sha256sum --check --status -
           tar -xzf cmake-3.31.12-macos-universal.tar.gz

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -54,6 +54,10 @@ jobs:
             runner: ubuntu-24.04
             toolchain_file: '${HOME}/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake'
 
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - uses: actions/checkout@v7
 
@@ -67,8 +71,10 @@ jobs:
       - name: Install build dependencies (macOS)
         if: matrix.os == 'macos'
         run: |
-          brew uninstall cmake
+          set -e
+          brew uninstall -y cmake || true
           wget -q https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-macos-universal.tar.gz
+          echo "799af7fd545db9bf1b9cfe72f8095880e727a2d4e0df0e3dffc3bc7b95c2d3b0 *cmake-3.31.12-macos-universal.tar.gz" | sha256sum --check --status -
           tar -xzf cmake-3.31.12-macos-universal.tar.gz
           sudo cp -r cmake-3.31.12-macos-universal/CMake.app /Applications/
           echo "/Applications/CMake.app/Contents/bin" >> $GITHUB_PATH
@@ -77,9 +83,11 @@ jobs:
       - name: Install build dependencies (MS DOS)
         if: matrix.os == 'msdos'
         run: |
+          set -e
           sudo apt-get update
           sudo apt-get install -y cmake ${{ matrix.extra_packages }}
           wget -q https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
+          echo "9464f17017d6ab1b2bb2df4ed82357b5bf692e6e2b7fee37e315638f3d505f00 *djgpp-linux64-gcc1220.tar.bz2" | sha256sum --check --status -
           tar -xjf djgpp-linux64-gcc1220.tar.bz2 -C "${{ runner.temp }}"
           echo "${{ runner.temp }}/djgpp/bin" >> $GITHUB_PATH
 
@@ -121,3 +129,4 @@ jobs:
           name: hacked-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/
           if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -87,7 +87,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake ${{ matrix.extra_packages }}
           wget -q https://github.com/andrewwutw/build-djgpp/releases/download/v3.4/djgpp-linux64-gcc1220.tar.bz2
-          echo "9464f17017d6ab1b2bb2df4ed82357b5bf692e6e2b7fee37e315638f3d505f00 *djgpp-linux64-gcc1220.tar.bz2" | sha256sum --check --status -
+          echo "8464f17017d6ab1b2bb2df4ed82357b5bf692e6e2b7fee37e315638f3d505f00 *djgpp-linux64-gcc1220.tar.bz2" | sha256sum --check --status -
           tar -xjf djgpp-linux64-gcc1220.tar.bz2 -C "${{ runner.temp }}"
           echo "${{ runner.temp }}/djgpp/bin" >> $GITHUB_PATH
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(Hacked)
 
 cmake_policy(SET CMP0077 NEW) # Abort if variables are not clearly set
 
+# Setting a C-Standard automatically reduces the available compilers; For example, MSVC is out.
+# See here for a good overview: https://en.cppreference.com/c/compiler_support/23
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17) # GoogleTest requires at least C++17
@@ -16,16 +18,22 @@ if (NOT DOS)
     include(cmake/modules/TestSupport.cmake)
 endif ()
 include(cmake/modules/SimpleDirectMediaLayer.cmake)
+include(cmake/modules/BuildRules.cmake)
 
 file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
 add_library(hacked-core STATIC ${LIB_CORE_SOURCES})
 target_include_directories(hacked-core PUBLIC "${PROJECT_SOURCE_DIR}/core/main/include")
+target_link_libraries(hacked-core
+        PRIVATE
+        BuildRules::common
+)
 
 if (NOT DOS)
     file(GLOB_RECURSE TEST_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/test/source/*.cpp")
     add_executable(hacked-core-test ${TEST_CORE_SOURCES})
     target_link_libraries(hacked-core-test
             hacked-core
+            BuildRules::common
             GTest::gmock_main
     )
     gtest_add_tests(TARGET hacked-core-test EXTRA_ARGS --gtest_shuffle)
@@ -46,6 +54,7 @@ if (EMSCRIPTEN)
 endif ()
 target_link_libraries(hacked
         hacked-core
+        BuildRules::common
         SDL3::SDL3-static
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,16 +12,8 @@ include(FetchContent)
 include(CTest)
 
 if (NOT DOS)
-    FetchContent_Declare(
-            googletest
-            URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
-            OVERRIDE_FIND_PACKAGE
-            EXCLUDE_FROM_ALL
-    )
-    # For Windows: Prevent overriding the parent project's compiler/linker settings
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-    include(GoogleTest)
+    # As long as djgpp does not support building GoogleTest, there is no testing capability on MS DOS.
+    include(cmake/modules/TestSupport.cmake)
 endif ()
 
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,25 +15,7 @@ if (NOT DOS)
     # As long as djgpp does not support building GoogleTest, there is no testing capability on MS DOS.
     include(cmake/modules/TestSupport.cmake)
 endif ()
-
-FetchContent_Declare(
-        SDL
-        GIT_REPOSITORY https://github.com/libsdl-org/SDL
-        # This is a semi-random tag after 3.14.12, but before a release
-        # It includes MS DOS support.
-        GIT_TAG 855cbec702f246661ff00a0bce9e0683012840c2
-        EXCLUDE_FROM_ALL
-)
-set(SDL_SHARED OFF CACHE BOOL "Disabled SDL shared lib" FORCE)
-set(SDL_STATIC ON CACHE BOOL "Enabled SDL static lib" FORCE)
-set(SDL_TEST OFF CACHE BOOL "Disable SDL Test" FORCE)
-set(SDL_INSTALL OFF CACHE BOOL "Disable SDL installation" FORCE)
-set(SDL_DISKAUDIO OFF CACHE BOOL "Disable SDL support for disk audio" FORCE)
-set(SDL_CAMERA OFF CACHE BOOL "Disable SDL support for camera" FORCE)
-set(SDL_X11_XSCRNSAVER OFF CACHE BOOL "Disable SDL xscreensaver dependency" FORCE)
-set(SDL_X11_XTEST OFF CACHE BOOL "Disable SDL xtest dependency" FORCE)
-set(SDL_GPU_OPENXR OFF CACHE BOOL "Disable SDL OpenXR support" FORCE)
-FetchContent_MakeAvailable(SDL)
+include(cmake/modules/SimpleDirectMediaLayer.cmake)
 
 file(GLOB_RECURSE LIB_CORE_SOURCES "${PROJECT_SOURCE_DIR}/core/main/source/*.c")
 add_library(hacked-core STATIC ${LIB_CORE_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,34 +49,4 @@ target_link_libraries(hacked
         SDL3::SDL3-static
 )
 
-# Toolchains may define extra libraries that should be included in the distribution.
-# This is primarily for MinGW, which needs some runtime libraries along with it.
-if (DEFINED TOOLCHAIN_DLL_DEPENDENCIES)
-    foreach (DLL ${TOOLCHAIN_DLL_DEPENDENCIES})
-        execute_process(
-                COMMAND ${CMAKE_C_COMPILER} -print-file-name=${DLL}
-                OUTPUT_VARIABLE DLL_PATH
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        if (EXISTS "${DLL_PATH}" AND NOT "${DLL_PATH}" STREQUAL "${DLL}")
-            install(FILES "${DLL_PATH}" DESTINATION .)
-        else ()
-            message(WARNING "DLL '${DLL}' not resolved - it will be missing in the package")
-        endif ()
-    endforeach ()
-endif ()
-
-install(TARGETS hacked
-        RUNTIME DESTINATION .
-)
-
-if (EMSCRIPTEN)
-    # As per CMake "bug", the additional files have to be manually taken into the installation directory as well.
-    # Reference:
-    # https://stackoverflow.com/questions/61865545/how-to-install-both-js-and-wasm-files-with-the-cmake-target-for-emscripten#comment140265783_70702138
-    install(FILES
-            "$<TARGET_FILE_DIR:hacked>/hacked.js"
-            "$<TARGET_FILE_DIR:hacked>/hacked.wasm"
-            DESTINATION .
-    )
-endif ()
+include(cmake/modules/InstallationRules.cmake)

--- a/app/source/main.c
+++ b/app/source/main.c
@@ -7,6 +7,8 @@ static SDL_Renderer *renderer = NULL;
 
 SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 {
+   (void)argc;
+   (void)argv;
    *appstate = NULL;
 
    SDL_SetAppMetadata("InkyBlackness - HackEd", "1.0", "io.github.inkyblackness.hacked");
@@ -27,6 +29,7 @@ SDL_AppResult SDL_AppInit(void **appstate, int argc, char *argv[])
 
 SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 {
+   (void)appstate;
    if (event->type == SDL_EVENT_QUIT)
    {
       return SDL_APP_SUCCESS;
@@ -36,6 +39,7 @@ SDL_AppResult SDL_AppEvent(void *appstate, SDL_Event *event)
 
 SDL_AppResult SDL_AppIterate(void *appstate)
 {
+   (void)appstate;
    const double now = ((double)SDL_GetTicks()) / 1000.0;
    /* choose the color for the frame we will draw. The sine wave trick makes it fade between colors smoothly. */
    const float red = (float)(0.5 + 0.5 * SDL_sin(now));
@@ -51,5 +55,7 @@ SDL_AppResult SDL_AppIterate(void *appstate)
 
 void SDL_AppQuit(void *appstate, SDL_AppResult result)
 {
+   (void)appstate;
+   (void)result;
    SDL_Log("Quitting");
 }

--- a/cmake/modules/BuildRules.cmake
+++ b/cmake/modules/BuildRules.cmake
@@ -1,0 +1,28 @@
+# Starting off with a fresh project, enabling all the warnings is a lofty goal, yet will help in the long run.
+add_library(build_rules_warnings_all INTERFACE)
+add_library(BuildRules::warnings::all ALIAS build_rules_warnings_all)
+target_compile_options(build_rules_warnings_all INTERFACE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall -Wextra -Wpedantic -Werror>
+        # MSVC: /WX for treating warnings as errors breaks for various 3rd-party includes, thus not included
+        $<$<CXX_COMPILER_ID:MSVC>:/W4 /Wall>
+)
+
+# Optimizations for speed are tricky, as they would require some sort of performance analysis to prove their worth.
+# However, we can assume a certain baseline to use.
+add_library(build_rules_optimizations_speed INTERFACE)
+add_library(BuildRules::optimizations::speed ALIAS build_rules_optimizations_speed)
+target_compile_options(build_rules_optimizations_speed INTERFACE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-O3>
+)
+target_link_options(build_rules_optimizations_speed INTERFACE
+        # LTO := Link Time Optimization
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-flto>
+)
+
+add_library(build_rules_common INTERFACE)
+add_library(BuildRules::common ALIAS build_rules_common)
+target_link_libraries(build_rules_common
+        INTERFACE
+        BuildRules::warnings::all
+        $<$<CONFIG:Release,RelWithDebInfo>:BuildRules::optimizations::speed>
+)

--- a/cmake/modules/InstallationRules.cmake
+++ b/cmake/modules/InstallationRules.cmake
@@ -1,0 +1,35 @@
+# Installation rules specify what needs to be put into a package for distribution.
+# They are relevant for the execution of
+# cmake --install <build-dir> --prefix <distribution-dir>
+
+install(TARGETS hacked
+        RUNTIME DESTINATION .
+)
+
+# Toolchains may define extra libraries that should be included in the distribution.
+# This is primarily for MinGW, which needs some runtime libraries along with it.
+if (DEFINED TOOLCHAIN_DLL_DEPENDENCIES)
+    foreach (DLL ${TOOLCHAIN_DLL_DEPENDENCIES})
+        execute_process(
+                COMMAND ${CMAKE_C_COMPILER} -print-file-name=${DLL}
+                OUTPUT_VARIABLE DLL_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if (EXISTS "${DLL_PATH}" AND NOT "${DLL_PATH}" STREQUAL "${DLL}")
+            install(FILES "${DLL_PATH}" DESTINATION .)
+        else ()
+            message(WARNING "DLL '${DLL}' not resolved - it will be missing in the package")
+        endif ()
+    endforeach ()
+endif ()
+
+if (EMSCRIPTEN)
+    # As per CMake "bug", the additional files have to be manually taken into the installation directory as well.
+    # Reference:
+    # https://stackoverflow.com/questions/61865545/how-to-install-both-js-and-wasm-files-with-the-cmake-target-for-emscripten#comment140265783_70702138
+    install(FILES
+            "$<TARGET_FILE_DIR:hacked>/hacked.js"
+            "$<TARGET_FILE_DIR:hacked>/hacked.wasm"
+            DESTINATION .
+    )
+endif ()

--- a/cmake/modules/SimpleDirectMediaLayer.cmake
+++ b/cmake/modules/SimpleDirectMediaLayer.cmake
@@ -1,0 +1,25 @@
+FetchContent_Declare(
+        SDL
+        GIT_REPOSITORY https://github.com/libsdl-org/SDL
+        # This is a semi-random tag after 3.14.12, but before a release
+        # It includes MS DOS support.
+        GIT_TAG 855cbec702f246661ff00a0bce9e0683012840c2
+        EXCLUDE_FROM_ALL
+)
+
+# Ensure only static libray is used
+set(SDL_SHARED OFF CACHE BOOL "Disabled SDL shared lib" FORCE)
+set(SDL_STATIC ON CACHE BOOL "Enabled SDL static lib" FORCE)
+
+# Disable unused build functions
+set(SDL_TEST OFF CACHE BOOL "Disable SDL Test" FORCE)
+set(SDL_INSTALL OFF CACHE BOOL "Disable SDL installation" FORCE)
+
+# Disable unused features
+set(SDL_DISKAUDIO OFF CACHE BOOL "Disable SDL support for disk audio" FORCE)
+set(SDL_CAMERA OFF CACHE BOOL "Disable SDL support for camera" FORCE)
+set(SDL_GPU_OPENXR OFF CACHE BOOL "Disable SDL OpenXR support" FORCE)
+set(SDL_X11_XSCRNSAVER OFF CACHE BOOL "Disable SDL xscreensaver dependency" FORCE)
+set(SDL_X11_XTEST OFF CACHE BOOL "Disable SDL xtest dependency" FORCE)
+
+FetchContent_MakeAvailable(SDL)

--- a/cmake/modules/TestSupport.cmake
+++ b/cmake/modules/TestSupport.cmake
@@ -1,0 +1,12 @@
+FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+        OVERRIDE_FIND_PACKAGE
+        EXCLUDE_FROM_ALL
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+include(GoogleTest)


### PR DESCRIPTION
This pull request refines the details of building:
* cleaned up `CMakeLists.txt`: extract some details into modules. Not using module path modification deliberately, to explicitly specify the files of the modules that are coming from this repository.
* Add common build flags
  * optimization in release builds
  * enable all warnings and treat them as errors, including necessary code changes
* build script upgrades
  * add some explicit commands and verifying the integrity of the downloaded files
